### PR TITLE
update ACTA template link

### DIFF
--- a/_data/links.yml
+++ b/_data/links.yml
@@ -63,3 +63,8 @@ open-logic:
   short-name: OLT
   url: https://openlogicproject.org
   
+acta-template:
+  name: ACTA template
+  short-name: ACTA
+  url: https://github.com/RasmusBlanck/ACTA-template/
+  

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,4 +1,19 @@
 - authors:
+  - first_name: Christian
+    id: 81121
+    last_name: Bennet
+    year_of_birth: 1954
+  - first_name: Rasmus
+    id: 85180
+    last_name: Blanck
+    year_of_birth: 1982
+  id: 316660
+  pubyear: 2022
+  sourceissue: '5'
+  sourcetitle: Theoria
+  sourcevolume: '88'
+  title: Never trust an unsound theory
+- authors:
   - first_name: Paul
     id: 664621
     last_name: Kindvall Gorbow
@@ -397,21 +412,6 @@
     \ / Editors: Agata Ciabattoni, Elaine Pimentel, Ruy J. G. B. de Queiroz"
   sourcevolume: null
   title: "Material Dialogues for\_First-Order Logic in\_Constructive Type Theory"
-- authors:
-  - first_name: Christian
-    id: 81121
-    last_name: Bennet
-    year_of_birth: 1954
-  - first_name: Rasmus
-    id: 85180
-    last_name: Blanck
-    year_of_birth: 1982
-  id: 316660
-  pubyear: 2022
-  sourceissue: '5'
-  sourcetitle: Theoria
-  sourcevolume: '88'
-  title: Never trust an unsound theory
 - authors:
   - first_name: Bahareh
     id: 444205

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -7,5 +7,5 @@ title: Logic group resources
 * Borrow a book from the **Logic Library** outside room C569.
 * Access [*Logical Theory*]({{ site.data.links['logical-theory'].url }}), our remix of the [Open Logic Text]({{ site.data.links['open-logic'].url }}).
 * Submit suggestions and corrections for this website at our [GitHub repository]({{ site.data.links['github-repo'].url }}).
-* Write your PhD thesis using the [ACTA LaTeX template]({% link assets/tex/ACTA2021.zip %}) (zip file, 300 kb) designed and kindly shared by Rasmus Blanck.
+* Write your PhD thesis using the [ACTA LaTeX template]({{ site.data.links['acta-template'].url }}) designed and kindly shared by Rasmus Blanck.
 * Read our [guide on getting started with LaTeX]({% link _pages/resources/learning-latex.md %}).


### PR DESCRIPTION
Hi Graham. Apparently, I took your advice a couple of years ago and created a Github repo for the ACTA template for easier distribution, but I never shared the link with anyone. So finally, I've updated the link on the resource page. 